### PR TITLE
Enhance OCR preprocessing and Tesseract configuration

### DIFF
--- a/image_processor.py
+++ b/image_processor.py
@@ -1,6 +1,5 @@
 import cv2
 import numpy as np
-from PIL import Image
 from typing import Tuple, Optional
 
 class ImageProcessor:
@@ -18,9 +17,13 @@ class ImageProcessor:
             numpy.ndarray: Loaded image or None if loading fails
         """
         try:
-            return cv2.imread(image_path)
+            img = cv2.imread(image_path)
+            if img is None:
+                print(f"Error loading image: File not found or corrupted at {image_path}")
+                return None
+            return img
         except Exception as e:
-            print(f"Error loading image: {e}")
+            print(f"Error loading image at {image_path}: {e}")
             return None
 
     @staticmethod
@@ -79,28 +82,74 @@ class ImageProcessor:
         return adjusted
 
     @staticmethod
-    def preprocess_for_ocr(image: np.ndarray) -> np.ndarray:
+    def preprocess_for_ocr(image: np.ndarray, 
+                           gaussian_kernel_size: Tuple[int, int] = (5, 5),
+                           use_otsu: bool = False,
+                           morph_kernel_size: Optional[Tuple[int, int]] = None
+                           ) -> np.ndarray:
         """
-        Apply basic preprocessing pipeline for OCR.
-        
+        Apply a preprocessing pipeline for OCR.
+
         Args:
-            image: Input image
-            
+            image: Input image (expected to be BGR if it has color).
+            gaussian_kernel_size: Kernel size for Gaussian blur. Default is (5, 5).
+            use_otsu: If True, use Otsu's thresholding instead of adaptive thresholding.
+                      Default is False.
+            morph_kernel_size: Kernel size for morphological opening (erosion then dilation).
+                               If None, this step is skipped. Example: (3,3). Default is None.
+                               
         Returns:
-            numpy.ndarray: Preprocessed image
+            numpy.ndarray: Preprocessed image (binary).
         """
+        print("Starting OCR preprocessing...")
         # Convert to grayscale
-        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-        
+        if len(image.shape) == 3 and image.shape[2] == 3:
+            gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+            print("Converted image to grayscale.")
+        elif len(image.shape) == 2:
+            gray = image # Already grayscale
+            print("Image is already grayscale.")
+        else: # Fallback for unexpected shapes, or could raise an error
+            gray = image 
+            print(f"Warning: Image has unexpected shape {image.shape}. Attempting to process as is.")
+
         # Apply Gaussian blur to reduce noise
-        blurred = cv2.GaussianBlur(gray, (5, 5), 0)
+        print(f"Applying Gaussian blur with kernel: {gaussian_kernel_size}")
+        blurred = cv2.GaussianBlur(gray, gaussian_kernel_size, 0)
         
-        # Apply adaptive thresholding
-        thresh = cv2.adaptiveThreshold(
-            blurred, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, 
-            cv2.THRESH_BINARY, 11, 2
-        )
+        # Apply thresholding
+        if use_otsu:
+            print("Applying Otsu's thresholding...")
+            # Otsu's thresholding automatically finds the optimal threshold value
+            _, thresh = cv2.threshold(blurred, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+        else:
+            print("Applying adaptive Gaussian thresholding...")
+            thresh = cv2.adaptiveThreshold(
+                blurred, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, 
+                cv2.THRESH_BINARY, 11, 2  # Default parameters for adaptive threshold
+            )
         
+        # Apply morphological operations if kernel size is provided
+        if morph_kernel_size:
+            # Ensure morph_kernel_size has positive integer values
+            if not (isinstance(morph_kernel_size, tuple) and 
+                    len(morph_kernel_size) == 2 and
+                    isinstance(morph_kernel_size[0], int) and morph_kernel_size[0] > 0 and
+                    isinstance(morph_kernel_size[1], int) and morph_kernel_size[1] > 0):
+                print(f"Invalid morph_kernel_size: {morph_kernel_size}. Skipping morphological operations.")
+            else:
+                print(f"Applying morphological opening with kernel: {morph_kernel_size}")
+                kernel = cv2.getStructuringElement(cv2.MORPH_RECT, morph_kernel_size)
+                # Erosion followed by Dilation (Opening)
+                eroded = cv2.erode(thresh, kernel, iterations=1)
+                print("Applied erosion.")
+                dilated = cv2.dilate(eroded, kernel, iterations=1)
+                print("Applied dilation.")
+                thresh = dilated # Update thresh with the result of morphological operations
+        else:
+            print("Skipping morphological operations.")
+            
+        print("OCR preprocessing finished.")
         return thresh
 
     @staticmethod
@@ -117,7 +166,8 @@ class ImageProcessor:
         """
         try:
             cv2.imwrite(output_path, image)
+            print(f"Image saved successfully to {output_path}")
             return True
         except Exception as e:
-            print(f"Error saving image: {e}")
-            return False 
+            print(f"Error saving image to {output_path}: {e}")
+            return False

--- a/ocr_engine.py
+++ b/ocr_engine.py
@@ -1,24 +1,80 @@
 import pytesseract
 from typing import Dict, Optional, Tuple
-import cv2
 import numpy as np
 
 class OCREngine:
-    """Wrapper for Tesseract OCR functionality."""
+    """
+    Wrapper for Tesseract OCR functionality.
+
+    Common Tesseract Page Segmentation Modes (PSM) (--psm option):
+      0    Orientation and script detection (OSD) only.
+      1    Automatic page segmentation with OSD.
+      2    Automatic page segmentation, but no OSD, or OCR.
+      3    Fully automatic page segmentation, but no OSD. (Default)
+      4    Assume a single column of text of variable sizes.
+      5    Assume a single uniform block of vertically aligned text.
+      6    Assume a single uniform block of text. (Used as default in this class)
+      7    Treat the image as a single text line.
+      8    Treat the image as a single word.
+      9    Treat the image as a single word in a circle.
+     10    Treat the image as a single character.
+     11    Sparse text. Find as much text as possible in no particular order.
+     12    Sparse text with OSD.
+     13    Raw line. Treat the image as a single text line,
+           bypassing hacks that are Tesseract-specific.
+    """
     
-    def __init__(self, config: Optional[Dict] = None):
+    def __init__(self, config: Optional[Dict[str, str]] = None):
         """
-        Initialize OCR engine with optional configuration.
+        Initialize OCR engine with optional Tesseract configuration.
         
+        The PSM (Page Segmentation Mode) can be set via the `config` dictionary.
+        If `config` is provided and contains a `'--psm'` key, its value will be used.
+        Otherwise, it defaults to '6'.
+
         Args:
-            config: Dictionary of Tesseract configuration parameters
+            config: Dictionary of Tesseract configuration parameters. 
+                    Example: `{'--psm': '7', 'tessedit_char_whitelist': '0123456789'}`
         """
-        self.config = config or {
+        default_config = {
             '--oem': '1',  # Use Legacy + LSTM OCR Engine Mode
-            '--psm': '6',  # Assume uniform block of text
+            '--psm': '6',  # Assume uniform block of text (default for this class)
             'tessedit_char_whitelist': '0123456789./-',  # Only look for numbers and basic symbols
         }
         
+        if config:
+            # Merge provided config with defaults, provided config takes precedence
+            self.config = {**default_config, **config}
+        else:
+            self.config = default_config
+        
+        print(f"OCREngine initialized with config: {self.config}")
+
+    def set_psm(self, psm_value: str):
+        """
+        Update the Page Segmentation Mode (PSM) for Tesseract.
+
+        Args:
+            psm_value: The new PSM value (e.g., '3', '6', '7').
+                       Refer to class docstring for common PSM values.
+        """
+        if not isinstance(psm_value, str):
+            print(f"Warning: PSM value should be a string. Attempting to use {psm_value} as string.")
+            psm_value = str(psm_value)
+            
+        self.config['--psm'] = psm_value
+        print(f"Tesseract PSM updated to: {psm_value}. Current config: {self.config}")
+
+    def _build_config_str(self) -> str:
+        """Helper method to build the Tesseract config string."""
+        config_str_parts = []
+        for k, v in self.config.items():
+            if k.startswith('--'):
+                config_str_parts.append(f'{k} {v}')
+            else:
+                config_str_parts.append(f'-c {k}={v}')
+        return ' '.join(config_str_parts)
+
     def extract_text(self, image: np.ndarray) -> str:
         """
         Extract text from preprocessed image.
@@ -30,14 +86,8 @@ class OCREngine:
             str: Extracted text
         """
         try:
-            # Build config string for Tesseract
-            config_str = ''
-            for k, v in self.config.items():
-                if k.startswith('--'):
-                    config_str += f'{k} {v} '
-                else:
-                    config_str += f'-c {k}={v} '
-            config_str = config_str.strip()
+            config_str = self._build_config_str()
+            print(f"Using Tesseract config for extract_text: '{config_str}'") # Logging added
             
             # Perform OCR
             text = pytesseract.image_to_string(
@@ -60,22 +110,17 @@ class OCREngine:
             float: Confidence score (0-100)
         """
         try:
-            config_str = ''
-            for k, v in self.config.items():
-                if k.startswith('--'):
-                    config_str += f'{k} {v} '
-                else:
-                    config_str += f'-c {k}={v} '
-            config_str = config_str.strip()
+            config_str = self._build_config_str()
+            # Not printing config_str here to avoid too much noise if called frequently with extract_with_confidence
             data = pytesseract.image_to_data(
                 image,
                 output_type=pytesseract.Output.DICT,
                 config=config_str
             )
             
-            # Calculate average confidence for non-empty text
+            # Calculate average confidence for non-empty text, ignoring negative confidences
             confidences = [int(conf) for conf, text in zip(data['conf'], data['text']) 
-                         if text.strip()]
+                         if text.strip() and int(conf) >= 0]
             return sum(confidences) / len(confidences) if confidences else 0.0
         except Exception as e:
             print(f"Error getting confidence: {e}")


### PR DESCRIPTION
This commit introduces several improvements to the OCR pipeline:

image_processor.py:
- The `preprocess_for_ocr` method now allows you to select the Gaussian blur kernel size.
- Added an option to use Otsu's thresholding as an alternative to adaptive thresholding.
- Implemented optional morphological 'opening' (erosion then dilation) to remove noise post-thresholding.
- Enhanced logging with print statements to detail the preprocessing steps being applied.
- Ensured informative error messages for image loading and saving.

ocr_engine.py:
- Tesseract Page Segmentation Mode (PSM) is now configurable during `OCREngine` initialization and can be changed post-initialization using a new `set_psm` method.
- Improved logging by printing the Tesseract configuration used for initialization and each OCR extraction.
- Refactored Tesseract config string generation for consistency.
- Confidence calculation now filters out negative confidence values.